### PR TITLE
Fix: DesiredRole field regex updated to allow spaces (#114)

### DIFF
--- a/src/main/java/seedu/address/model/person/DesiredRole.java
+++ b/src/main/java/seedu/address/model/person/DesiredRole.java
@@ -14,7 +14,7 @@ public class DesiredRole {
     /*
      * The first character of the desired role must not be a whitespace.
      */
-    public static final String VALIDATION_REGEX = "[A-Za-z][A-Za-z0-9 ]*";
+    public static final String VALIDATION_REGEX = "^[A-Za-z][A-Za-z0-9 /]*$";
 
     public final String value;
 


### PR DESCRIPTION
close #114 
**Objective**  
This pull request addresses an issue where the **DesiredRole** field did not accept spaces, causing inconvenience when users attempted to add multiple-word skills.

**Changes Made**  
- Updated the regex pattern in the **DesiredRole** field 
- Tested the regex update to ensure it handles both single-word and multi-word inputs correctly.
- Desired role doesn't accept "/"



**Review Notes**  
- Please review the regex changes and verify that it covers various scenarios.
- Let me know if additional test cases are needed for edge cases.