### PR TITLE
fix: Display error message for invalid status in filter command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -325,23 +325,35 @@ Filters candidates based on their status.
 #### Notes
 
 - **Case-Insensitive**: The search is case-insensitive.
-- **Available Statuses**: Active, Shortlisted, Hired, etc.
+- **Available Statuses**:
+    - Applied
+    - Screening
+    - Interview Scheduled
+    - Interviewed
+    - Offer
+    - Onboarding
+    - Hired
+    - Rejected
 
-<u>Examples<u>
+#### Examples
 
-- `filter st/Active`: Displays all active candidates.
-- `filter st/Shortlisted`: Shows candidates marked as shortlisted.
+- `filter st/Applied`: Displays all candidates marked as "Applied".
+- `filter st/Interviewed`: Shows candidates marked as "Interviewed".
 
-<u>Image Example<u>
+#### Image Example
 
-Command: ` filter screening `
+Command: `filter screening`
 
-Before the find command ran:
+**Before the filter command ran:**
 <img src="images/beforefilter.png" alt="beforefilter.png" width="800">
 
-
-After the find command ran:
+**After the filter command ran:**
 <img src="images/afterfilter.png" alt="afterfilter.png" width="800">
+
+#### Invalid Status
+
+If an invalid status is input (e.g., `filter applying`), an error message will appear:
+> **Invalid status: applying. Valid statuses are: Applied, Screening, Interview Scheduled, Interviewed, Offer, Onboarding, Hired, Rejected**
 
 
 ---

--- a/src/main/java/seedu/address/logic/parser/FilterStatusCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterStatusCommandParser.java
@@ -3,30 +3,43 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
+import java.util.List;
 
 import seedu.address.logic.commands.FilterStatusCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Status;
 import seedu.address.model.person.StatusContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FilterStatusCommand object
  */
 public class FilterStatusCommandParser implements Parser<FilterStatusCommand> {
-
+    public static final List<String> VALID_STATUSES = Arrays.asList(
+        "Applied", "Screening", "Interview Scheduled", "Interviewed",
+        "Offer", "Onboarding", "Hired", "Rejected"
+    );
     /**
      * Parses the given {@code String} of arguments in the context of the FilterStatusCommand
      * and returns a FilterStatusCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform to the expected format
      */
     public FilterStatusCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterStatusCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterStatusCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        String[] statusKeywords = trimmedArgs.split("\\s+");
 
-        return new FilterStatusCommand(new StatusContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        // Validate each keyword using Status.VALID_STATUSES
+        for (String keyword : statusKeywords) {
+            if (!Status.VALID_STATUSES.contains(keyword)) {
+                throw new ParseException("Invalid status: " + keyword + ". Valid statuses are: "
+                    + String.join(", ", Status.VALID_STATUSES));
+            }
+        }
+
+        return new FilterStatusCommand(new StatusContainsKeywordsPredicate(Arrays.asList(statusKeywords)));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FilterStatusCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterStatusCommandParserTest.java
@@ -12,7 +12,7 @@ import seedu.address.logic.commands.FilterStatusCommand;
 import seedu.address.model.person.StatusContainsKeywordsPredicate;
 
 public class FilterStatusCommandParserTest {
-    private FilterStatusCommandParser parser = new FilterStatusCommandParser();
+    private final FilterStatusCommandParser parser = new FilterStatusCommandParser();
 
     @Test
     public void parse_emptyArg_throwsParseException() {
@@ -29,5 +29,31 @@ public class FilterStatusCommandParserTest {
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " \n Applied \n \t Hired  \t", expectedFilterStatusCommand);
+    }
+
+    @Test
+    public void parse_invalidArg_throwsParseException() {
+        // single invalid status
+        assertParseFailure(parser, "Recruited", "Invalid status: Recruited. Valid statuses are: "
+            + String.join(", ", FilterStatusCommandParser.VALID_STATUSES));
+
+        // multiple invalid statuses
+        assertParseFailure(parser, "Applied Recruited", "Invalid status: Recruited. Valid statuses are: "
+            + String.join(", ", FilterStatusCommandParser.VALID_STATUSES));
+
+        // multiple invalid statuses
+        assertParseFailure(parser, "Fired Screened", "Invalid status: Fired. Valid statuses are: "
+            + String.join(", ", FilterStatusCommandParser.VALID_STATUSES));
+    }
+
+    @Test
+    public void parse_mixedValidAndInvalidArgs_throwsParseException() {
+        // valid and invalid statuses mixed
+        assertParseFailure(parser, "Applied Recruited Hired", "Invalid status: Recruited. Valid statuses are: "
+            + String.join(", ", FilterStatusCommandParser.VALID_STATUSES));
+
+        // another case with mixed valid and invalid statuses
+        assertParseFailure(parser, "Screening Promoted", "Invalid status: Promoted. Valid statuses are: "
+            + String.join(", ", FilterStatusCommandParser.VALID_STATUSES));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FilterStatusCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterStatusCommandParserTest.java
@@ -17,17 +17,17 @@ public class FilterStatusCommandParserTest {
     @Test
     public void parse_emptyArg_throwsParseException() {
         assertParseFailure(parser, "     ",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterStatusCommand.MESSAGE_USAGE));
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterStatusCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_validArgs_returnsFilterStatusCommand() {
         // no leading and trailing whitespaces
         FilterStatusCommand expectedFilterStatusCommand =
-                new FilterStatusCommand(new StatusContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFilterStatusCommand);
+            new FilterStatusCommand(new StatusContainsKeywordsPredicate(Arrays.asList("Applied", "Hired")));
+        assertParseSuccess(parser, "Applied Hired", expectedFilterStatusCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFilterStatusCommand);
+        assertParseSuccess(parser, " \n Applied \n \t Hired  \t", expectedFilterStatusCommand);
     }
 }


### PR DESCRIPTION
Closes #124
Added validation to `FilterStatusCommandParser` to handle cases where an invalid status is entered. Now, an error message is shown when the user inputs an unrecognized status (e.g., 'applying') instead of displaying an empty list. This improves user feedback and usability.

